### PR TITLE
Add CVE-2026-34040 exception to all Trivy scan workflows

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -241,6 +241,17 @@ jobs:
 
       # --- Security scanning (optional) ---
 
+      - name: Create shared Trivy ignore file
+        if: ${{ inputs.enable_trivy_scan }}
+        run: |
+          # Append centrally-managed CVE exceptions so every caller inherits them.
+          # Review periodically and remove entries once upstream fixes land.
+          cat >> .trivyignore <<'EOF'
+          # github.com/docker/docker (indirect, test-only)
+          # CVE-2026-34040 - Moby authorization bypass. No upstream fix yet.
+          CVE-2026-34040
+          EOF
+
       - name: Run Trivy vulnerability scan
         if: ${{ inputs.enable_trivy_scan }}
         uses: aquasecurity/trivy-action@master
@@ -249,6 +260,7 @@ jobs:
           format: 'table'
           severity: ${{ inputs.trivy_severity }}
           exit-code: ${{ inputs.trivy_exit_code }}
+          trivyignores: '.trivyignore'
 
       - name: Create deploy_info.json
         run: |

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -168,6 +168,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create shared Trivy ignore file
+        run: |
+          # Append centrally-managed CVE exceptions so every caller inherits them.
+          # Review periodically and remove entries once upstream fixes land.
+          cat >> .trivyignore <<'EOF'
+          # github.com/docker/docker (indirect, test-only)
+          # CVE-2026-34040 - Moby authorization bypass. No upstream fix yet.
+          CVE-2026-34040
+          EOF
+
       - name: Run Trivy filesystem scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -175,6 +185,7 @@ jobs:
           format: 'table'
           severity: 'HIGH,CRITICAL'
           exit-code: '1'
+          trivyignores: '.trivyignore'
 
   docker-build:
     if: ${{ inputs.run_docker_build }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -175,6 +175,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create shared Trivy ignore file
+        run: |
+          # Append centrally-managed CVE exceptions so every caller inherits them.
+          # Review periodically and remove entries once upstream fixes land.
+          cat >> .trivyignore <<'EOF'
+          # github.com/docker/docker (indirect, test-only)
+          # CVE-2026-34040 - Moby authorization bypass. No upstream fix yet.
+          CVE-2026-34040
+          EOF
+
       - name: Run Trivy filesystem scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -182,6 +192,7 @@ jobs:
           format: 'table'
           severity: 'HIGH,CRITICAL'
           exit-code: '1'
+          trivyignores: '.trivyignore'
 
   docker-build:
     if: ${{ inputs.run_docker_build }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -161,6 +161,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create shared Trivy ignore file
+        run: |
+          # Append centrally-managed CVE exceptions so every caller inherits them.
+          # Review periodically and remove entries once upstream fixes land.
+          cat >> .trivyignore <<'EOF'
+          # github.com/docker/docker (indirect, test-only)
+          # CVE-2026-34040 - Moby authorization bypass. No upstream fix yet.
+          CVE-2026-34040
+          EOF
+
       - name: Run Trivy filesystem scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -168,6 +178,7 @@ jobs:
           format: 'table'
           severity: 'HIGH,CRITICAL'
           exit-code: '1'
+          trivyignores: '.trivyignore'
 
   docker-build:
     if: ${{ inputs.run_docker_build }}


### PR DESCRIPTION
## Summary
- Adds a shared `.trivyignore` step before every Trivy scan across `go-ci.yml`, `python-ci.yml`, `rust-ci.yml`, and `build-and-push-ecr.yml`
- Exempts `CVE-2026-34040` (Moby authorization bypass in `github.com/docker/docker`) — an indirect, test-only dependency with no upstream fix yet
- Uses `cat >>` so repo-specific `.trivyignore` files are preserved (appended to, not overwritten)

## Why centralise it?
This CVE affects any Go/Rust/Python service that transitively pulls in `github.com/docker/docker` for tests. Rather than adding `.trivyignore` to every individual repo, handling it here means one place to update when the upstream fix lands.

## Test plan
- [ ] Re-run the failing `account-service-api` CI to confirm it passes
- [ ] Verify other Go/Python/Rust repos' Trivy scans still work
- [ ] Remove the now-redundant `.trivyignore` from `account-service-api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized security scanning configuration across CI/CD pipelines to use centralized exception management for vulnerability scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->