### PR TITLE
fix: YAML parse error in dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,10 +21,11 @@ jobs:
 
       - name: Approve minor and patch updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr review "$PR_URL" --approve --body "Auto-approved: ${{ steps.metadata.outputs.update-type }}"
+        run: gh pr review "$PR_URL" --approve --body "$APPROVE_BODY"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPROVE_BODY: "Auto-approved: ${{ steps.metadata.outputs.update-type }}"
 
       - name: Enable auto-merge for minor and patch updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'


### PR DESCRIPTION
## Summary
- Line 24 had `${{ }}` expression nested inside a double-quoted YAML `run:` string, causing a parse error in caller workflows
- Moved the interpolated body into an `APPROVE_BODY` env var to avoid YAML syntax ambiguity

## Test plan
- [ ] Verify caller workflows (e.g. `stream-generator`) no longer fail with YAML parse error
- [ ] Trigger a dependabot PR to confirm auto-approve still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)