### PR TITLE
Upgrade super-linter to v7, add eslint and jscpd controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,18 @@ on:
         type: boolean
         default: false
 
+      disable-eslint:
+        description: 'Disable ESLint-based linters (JS, JSX, TS, TSX, JSON, JSONC). Use for repos with ESLint flat config'
+        required: false
+        type: boolean
+        default: false
+
+      jscpd-threshold:
+        description: 'JSCPD duplication threshold percentage (0-100). Set to 0 to use repo .jscpd.json or jscpd default'
+        required: false
+        type: number
+        default: 0
+
       extra-super-linter-env:
         description: 'Extra Super-Linter env vars as KEY=VALUE pairs separated by newlines'
         required: false
@@ -84,6 +96,8 @@ jobs:
       disable-checkov: ${{ inputs.disable-checkov }}
       disable-jscpd: ${{ inputs.disable-jscpd }}
       disable-gitleaks: ${{ inputs.disable-gitleaks }}
+      disable-eslint: ${{ inputs.disable-eslint }}
+      jscpd-threshold: ${{ inputs.jscpd-threshold }}
       extra-super-linter-env: ${{ inputs.extra-super-linter-env }}
 
   frontend-ci:

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -28,6 +28,16 @@ on:
         required: false
         type: boolean
         default: false
+      disable-eslint:
+        description: "Disable ESLint-based linters (JS, JSX, TS, TSX, JSON, JSONC). Use for repos with ESLint flat config (eslint.config.js)"
+        required: false
+        type: boolean
+        default: false
+      jscpd-threshold:
+        description: "JSCPD duplication threshold percentage (0-100). Set to 0 to use repo .jscpd.json or jscpd default"
+        required: false
+        type: number
+        default: 0
 
 jobs:
   lint:
@@ -58,9 +68,28 @@ jobs:
           if [ "${{ inputs.disable-gitleaks }}" = "true" ]; then
             echo "VALIDATE_GITLEAKS=false" >> "$GITHUB_ENV"
           fi
+          if [ "${{ inputs.disable-eslint }}" = "true" ]; then
+            echo "VALIDATE_JAVASCRIPT_ES=false" >> "$GITHUB_ENV"
+            echo "VALIDATE_JSX=false" >> "$GITHUB_ENV"
+            echo "VALIDATE_TYPESCRIPT_ES=false" >> "$GITHUB_ENV"
+            echo "VALIDATE_TSX=false" >> "$GITHUB_ENV"
+            echo "VALIDATE_JSON=false" >> "$GITHUB_ENV"
+            echo "VALIDATE_JSONC=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Set JSCPD threshold
+        if: ${{ inputs.jscpd-threshold > 0 && !inputs.disable-jscpd }}
+        run: |
+          if [ ! -f .jscpd.json ]; then
+            echo '{"threshold": ${{ inputs.jscpd-threshold }}}' > .jscpd.json
+          else
+            # Update threshold in existing config
+            tmp=$(mktemp)
+            jq '.threshold = ${{ inputs.jscpd-threshold }}' .jscpd.json > "$tmp" && mv "$tmp" .jscpd.json
+          fi
 
       - name: Run Super-Linter
-        uses: github/super-linter@v6
+        uses: super-linter/super-linter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Run Super-Linter
-        uses: super-linter/super-linter@v7
+        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
## Summary

- Upgrades `github/super-linter@v6` to `super-linter/super-linter@v7`
- Adds `disable-eslint` input to disable all ESLint-based linters (JS, JSX, TS, TSX, JSON, JSONC) for repos using ESLint flat config (`eslint.config.js`)
- Adds `jscpd-threshold` input so repos can set an acceptable duplication percentage without needing a `.jscpd.json` file

Both inputs are available in `super-lint.yml` directly and passed through from `ci.yml`. All defaults preserve current behavior (eslint enabled, 0% threshold).

### Context

hub-next CI is failing because:
1. **JSCPD** threshold is 0% but the repo has 14.78% duplication — now configurable via `jscpd-threshold`
2. **ESLint** flat config (`eslint.config.js`) is incompatible with super-linter's `--eslintrc` flag — now fixable via `disable-eslint: true`

### Usage in hub-next

After this merges, hub-next's `ci.yml` can add:
```yaml
with:
  disable-eslint: true
  jscpd-threshold: 20
```

## Test plan

- [ ] Verify existing repos using the workflow are unaffected (all defaults unchanged)
- [ ] Test with hub-next using `disable-eslint: true` and `jscpd-threshold: 20`
- [ ] Confirm super-linter v7 runs without errors on a repo without flat config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline now accepts new options to toggle ESLint-based checks and set a JavaScript duplication threshold for linting.
  * Linting job forwards these options to the shared linter workflow for consistent behavior.
  * Upgraded the integrated linter to the latest major release for improved capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/signapse/reusable-workflows/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->