### PR TITLE
Default go_arch to arm64 for Lambda deploys

### DIFF
--- a/.github/workflows/go-lambda-deploy.yml
+++ b/.github/workflows/go-lambda-deploy.yml
@@ -74,7 +74,7 @@ on:
         description: 'Target architecture for the Go binary (e.g., amd64, arm64)'
         required: false
         type: string
-        default: 'amd64'
+        default: 'arm64'
 
       app_version:
         description: 'Application version to display in the Lambda description (e.g., v1.2.3, github.event.release.tag_name)'


### PR DESCRIPTION
## Summary
- Change default `go_arch` from `amd64` to `arm64` in `go-lambda-deploy.yml`
- All new Lambda infrastructure uses Graviton (arm64), so this should be the default
- Existing callers that need x86_64 can explicitly pass `go_arch: 'amd64'`

## Test plan
- [ ] Verify existing Lambda deploy workflows still work (callers not passing `go_arch` will now get arm64)
- [ ] Any service still on x86_64 infra should add `go_arch: 'amd64'` explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default deployment architecture configuration for serverless Lambda deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->